### PR TITLE
Add Eel web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ pip install -r requirements.txt
 python tool.py
 # To create a binary distribution, you could:
 python build.py
+# To run the new web interface:
+python web_tool.py
 ````
 ***
 # About

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wmi
 httpx
 cryptography
 toml
+Eel>=0.16.0

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -1,0 +1,17 @@
+import eel
+
+# Sample battery data
+BATTERIES = [100, 80, 50, 20]
+
+eel.init('src/webui/web')
+
+@eel.expose
+def get_batteries():
+    return BATTERIES
+
+def start():
+    # Use mode="none" to allow running in environments without a browser
+    eel.start('index.html', mode='none', size=(360, 200))
+
+if __name__ == '__main__':
+    start()

--- a/src/webui/web/index.html
+++ b/src/webui/web/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Batteries</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="widget-container" id="container">
+        <!-- Devices will be inserted here -->
+    </div>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/src/webui/web/script.js
+++ b/src/webui/web/script.js
@@ -1,0 +1,25 @@
+async function init() {
+    const data = await eel.get_batteries()();
+    const container = document.getElementById('container');
+    data.forEach(value => {
+        const device = document.createElement('div');
+        device.className = 'device-container';
+
+        const circle = document.createElement('div');
+        circle.className = 'progress-circle';
+        const fill = document.createElement('div');
+        fill.className = 'fill';
+        fill.style.setProperty('--value', value + '%');
+        circle.appendChild(fill);
+
+        const reading = document.createElement('div');
+        reading.className = 'reading';
+        reading.textContent = value + '%';
+
+        device.appendChild(circle);
+        device.appendChild(reading);
+        container.appendChild(device);
+    });
+}
+
+init();

--- a/src/webui/web/style.css
+++ b/src/webui/web/style.css
@@ -1,0 +1,60 @@
+body {
+    background: #202020;
+    color: #E6EDED;
+    font-family: 'SF Pro Text', sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.widget-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 17.5px;
+    width: 338px;
+    height: 158px;
+    background: linear-gradient(0deg, #9C9C9C, #9C9C9C), rgba(37, 37, 37, 0.55);
+    background-blend-mode: overlay, normal;
+    backdrop-filter: blur(50px);
+    border-radius: 22px;
+    padding: 20px;
+}
+
+.device-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 17px;
+    width: 62px;
+}
+
+.progress-circle {
+    position: relative;
+    width: 62px;
+    height: 62px;
+    border-radius: 50%;
+    background: rgba(217, 217, 217, 0.2);
+    overflow: hidden;
+}
+
+.progress-circle .fill {
+    position: absolute;
+    width: 62px;
+    height: 62px;
+    border-radius: 50%;
+    background: #34C85A;
+    bottom: 0;
+    clip-path: inset(calc(100% - var(--value)) 0 0 0);
+}
+
+.reading {
+    font-family: 'SF Pro Display', sans-serif;
+    font-size: 22px;
+    line-height: 16px;
+    text-align: center;
+    color: #E6EDED;
+}

--- a/web_tool.py
+++ b/web_tool.py
@@ -1,0 +1,4 @@
+from src.webui.app import start
+
+if __name__ == '__main__':
+    start()


### PR DESCRIPTION
## Summary
- add simple Eel-based web UI
- include sample HTML/CSS/JS assets
- update README with new run instructions
- add Eel to requirements

## Testing
- `python -m py_compile web_tool.py src/webui/app.py`
- `pip install Eel>=0.16.0`

------
https://chatgpt.com/codex/tasks/task_e_684fd769847483308051e22f4a68bd53