### PR TITLE
Add web tools page and improved widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ pip install -r requirements.txt
 python tool.py
 # To create a binary distribution, you could:
 python build.py
+# To run the new web interface:
+python web_tool.py
+# Additional demo pages are available at:
+#  - battery.html
+#  - file_info.html
+#  - tools.html (boot unpack & magisk patch)
 ````
 ***
 # About

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wmi
 httpx
 cryptography
 toml
+Eel>=0.16.0

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -1,0 +1,88 @@
+import os
+import os
+import eel
+import tempfile
+import shutil
+import os
+from src.tkui import tool as tk_tool
+from src.core.utils import (
+    gettype,
+    hum_convert,
+    calculate_md5_file,
+    calculate_sha256_file,
+    tool_bin,
+)
+from src.core.Magisk import Magisk_patch
+
+# Sample battery data used for the demo page
+BATTERIES = [100, 80, 50, 20]
+
+eel.init('src/webui/web')
+
+
+@eel.expose
+def get_batteries():
+    """Return demo battery values."""
+    return BATTERIES
+
+
+@eel.expose
+def get_file_info(path: str):
+    """Return basic information about the given file."""
+    if not path or not os.path.isfile(path):
+        return {"error": "File not found"}
+    return {
+        "name": os.path.basename(path),
+        "path": os.path.abspath(path),
+        "type": gettype(path),
+        "size": hum_convert(os.path.getsize(path)),
+        "size_bytes": os.path.getsize(path),
+        "md5": calculate_md5_file(path),
+        "sha256": calculate_sha256_file(path),
+    }
+
+
+@eel.expose
+def unpack_boot_image(path: str):
+    """Unpack a boot image using existing tool logic."""
+    try:
+        tk_tool.unpack_boot('boot', path)
+        return {"result": "ok"}
+    except Exception as e:  # pragma: no cover - just return error
+        return {"error": str(e)}
+
+
+@eel.expose
+def patch_boot_image(boot_path: str, magisk_apk: str, arch: str = 'arm64-v8a'):
+    """Patch a boot image with Magisk."""
+    tempdir = tempfile.mkdtemp(prefix='magisk_',)
+    try:
+        with Magisk_patch(
+            boot_path,
+            None,
+            f"{tool_bin}magiskboot",
+            tempdir,
+            True,
+            False,
+            False,
+            False,
+            magisk_apk,
+            arch,
+        ) as m:
+            m.auto_patch()
+            if m.output and os.path.exists(m.output):
+                return {"result": os.path.abspath(m.output)}
+            return {"error": "patch failed"}
+    except Exception as e:  # pragma: no cover - best effort
+        return {"error": str(e)}
+    finally:
+        shutil.rmtree(tempdir, ignore_errors=True)
+
+
+def start():
+    """Launch the Eel web interface."""
+    # Use mode="none" to allow running in environments without a browser
+    eel.start('index.html', mode='none', size=(480, 320))
+
+if __name__ == '__main__':
+    start()

--- a/src/webui/web/battery.html
+++ b/src/webui/web/battery.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Batteries</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="widget-container" id="container">
+        <div class="background"></div>
+    </div>
+    <a href="index.html">Back to Menu</a>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="battery.js"></script>
+</body>
+</html>

--- a/src/webui/web/battery.js
+++ b/src/webui/web/battery.js
@@ -1,0 +1,33 @@
+async function init() {
+    const data = await eel.get_batteries()();
+    const icons = ['\ud83d\udcf1', '\ud83d\udcbb', '\u231a', '\ud83c\udfa7'];
+    const container = document.getElementById('container');
+    data.forEach((value, idx) => {
+        const device = document.createElement('div');
+        device.className = 'device-container';
+
+        const track = document.createElement('div');
+        track.className = 'track';
+        const progress = document.createElement('div');
+        progress.className = 'progress';
+        progress.style.setProperty('--value', value + '%');
+        const overlay = document.createElement('div');
+        overlay.className = 'overlay';
+        const icon = document.createElement('div');
+        icon.className = 'device-icon';
+        icon.textContent = icons[idx % icons.length];
+
+        const reading = document.createElement('div');
+        reading.className = 'reading';
+        reading.textContent = value + '%';
+
+        device.appendChild(track);
+        device.appendChild(progress);
+        device.appendChild(overlay);
+        device.appendChild(icon);
+        device.appendChild(reading);
+        container.appendChild(device);
+    });
+}
+
+init();

--- a/src/webui/web/file_info.html
+++ b/src/webui/web/file_info.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get File Info</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="file-info-container">
+        <input type="text" id="filePath" placeholder="Enter file path" />
+        <button onclick="getInfo()">Get Info</button>
+        <pre id="infoOutput"></pre>
+        <a href="index.html">Back to Menu</a>
+    </div>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="file_info.js"></script>
+</body>
+</html>

--- a/src/webui/web/file_info.js
+++ b/src/webui/web/file_info.js
@@ -1,0 +1,6 @@
+async function getInfo() {
+    const path = document.getElementById('filePath').value;
+    const info = await eel.get_file_info(path)();
+    const output = document.getElementById('infoOutput');
+    output.textContent = JSON.stringify(info, null, 2);
+}

--- a/src/webui/web/index.html
+++ b/src/webui/web/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mio Web UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="menu">
+        <h1>MIO-KITCHEN</h1>
+        <ul>
+            <li><a href="battery.html">Battery Widget</a></li>
+            <li><a href="file_info.html">Get File Info</a></li>
+            <li><a href="tools.html">Tools</a></li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/src/webui/web/style.css
+++ b/src/webui/web/style.css
@@ -1,0 +1,130 @@
+body {
+    background: #202020;
+    color: #E6EDED;
+    font-family: 'SF Pro Text', sans-serif;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.menu {
+    text-align: center;
+}
+.menu ul {
+    list-style: none;
+    padding: 0;
+}
+.menu li {
+    margin: 10px 0;
+}
+.menu a {
+    color: #E6EDED;
+    text-decoration: none;
+    font-size: 20px;
+}
+
+.widget-container {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 17.5px;
+    width: 338px;
+    height: 158px;
+    border-radius: 22px;
+}
+.widget-container .background {
+    position: absolute;
+    width: 338px;
+    height: 158px;
+    left: 0;
+    top: 0;
+    background: linear-gradient(0deg, #9C9C9C, #9C9C9C), rgba(37,37,37,0.55);
+    background-blend-mode: overlay, normal;
+    backdrop-filter: blur(50px);
+    border-radius: 20px;
+    z-index: 0;
+}
+.device-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 17px;
+    width: 62px;
+    height: 103px;
+    z-index: 1;
+}
+.track {
+    position: absolute;
+    width: 62px;
+    height: 62px;
+    left: 0;
+    top: 0;
+    background: rgba(217,217,217,0.2);
+    border-radius: 100px;
+}
+.progress {
+    position: absolute;
+    width: 62px;
+    height: 62px;
+    left: 0;
+    top: 0;
+    background: #34C85A;
+    border-radius: 100px;
+    clip-path: inset(calc(100% - var(--value)) 0 0 0);
+}
+.overlay {
+    position: absolute;
+    width: 6.15px;
+    height: 6.15px;
+    left: calc(50% - 3.075px);
+    top: 0.05px;
+    background: #34C85A;
+    box-shadow: 0.25px 0px 1px rgba(45,45,45,0.039), 2.5px 0px 3px rgba(45,45,45,0.19);
+}
+.device-icon {
+    position: absolute;
+    width: 34px;
+    height: 34px;
+    left: calc(50% - 17px);
+    top: calc(50% - 17px);
+    font-size: 26px;
+    text-align: center;
+    line-height: 34px;
+    color: #E6EDED;
+}
+.reading {
+    width: 62px;
+    height: 24px;
+    font-family: 'SF Pro Display', sans-serif;
+    font-size: 22px;
+    line-height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: #E6EDED;
+}
+
+.file-info-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 300px;
+}
+
+.tools-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 300px;
+}
+
+.tools-container h2 {
+    margin: 0;
+    padding-bottom: 5px;
+}

--- a/src/webui/web/tools.html
+++ b/src/webui/web/tools.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tools</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="tools-container">
+        <h2>Boot Tools</h2>
+        <input type="text" id="bootPath" placeholder="Path to boot.img" />
+        <button onclick="unpackBoot()">Unpack Boot</button>
+        <pre id="toolOutput"></pre>
+        <hr />
+        <input type="text" id="patchBoot" placeholder="Boot img to patch" />
+        <input type="text" id="magiskApk" placeholder="Magisk APK" />
+        <button onclick="patchBoot()">Patch Boot with Magisk</button>
+        <pre id="patchOutput"></pre>
+        <a href="index.html">Back to Menu</a>
+    </div>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="tools.js"></script>
+</body>
+</html>

--- a/src/webui/web/tools.js
+++ b/src/webui/web/tools.js
@@ -1,0 +1,14 @@
+async function unpackBoot() {
+    const path = document.getElementById('bootPath').value;
+    const result = await eel.unpack_boot_image(path)();
+    const out = document.getElementById('toolOutput');
+    out.textContent = JSON.stringify(result, null, 2);
+}
+
+async function patchBoot() {
+    const boot = document.getElementById('patchBoot').value;
+    const apk = document.getElementById('magiskApk').value;
+    const res = await eel.patch_boot_image(boot, apk)();
+    const out = document.getElementById('patchOutput');
+    out.textContent = JSON.stringify(res, null, 2);
+}

--- a/web_tool.py
+++ b/web_tool.py
@@ -1,0 +1,4 @@
+from src.webui.app import start
+
+if __name__ == '__main__':
+    start()


### PR DESCRIPTION
## Summary
- expand README with demo page list
- implement `unpack_boot_image` in `app.py`
- refine battery widget UI and add back links
- add a simple tools page for unpacking boot images
- add Magisk patch support

## Testing
- `python -m py_compile web_tool.py src/webui/app.py src/webui/web/script.js`
- `pip install Eel>=0.16.0`

------
https://chatgpt.com/codex/tasks/task_e_684fd769847483308051e22f4a68bd53