### PR TITLE
Improve web UI with file dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ pip install -r requirements.txt
 python tool.py
 # To create a binary distribution, you could:
 python build.py
+# To run the polished web UI:
+python web_tool.py
+# The interface now mirrors the Qt layout using HTML and CSS.
+# Additional demo pages are available at:
+#  - battery.html
+#  - file_info.html
+#  - tools.html (boot unpack & magisk patch)
+# File inputs now support native dialogs via the new browse buttons.
 ````
 ***
 # About

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ wmi
 httpx
 cryptography
 toml
+Eel>=0.16.0

--- a/src/webui/app.py
+++ b/src/webui/app.py
@@ -1,0 +1,102 @@
+import os
+import eel
+import tempfile
+import shutil
+from src.tkui import tool as tk_tool
+from src.core.utils import (
+    gettype,
+    hum_convert,
+    calculate_md5_file,
+    calculate_sha256_file,
+    tool_bin,
+)
+from src.core.Magisk import Magisk_patch
+
+# Sample battery data used for the demo page
+BATTERIES = [100, 80, 50, 20]
+
+eel.init('src/webui/web')
+
+
+@eel.expose
+def get_batteries():
+    """Return demo battery values."""
+    return BATTERIES
+
+
+@eel.expose
+def get_file_info(path: str):
+    """Return basic information about the given file."""
+    if not path or not os.path.isfile(path):
+        return {"error": "File not found"}
+    return {
+        "name": os.path.basename(path),
+        "path": os.path.abspath(path),
+        "type": gettype(path),
+        "size": hum_convert(os.path.getsize(path)),
+        "size_bytes": os.path.getsize(path),
+        "md5": calculate_md5_file(path),
+        "sha256": calculate_sha256_file(path),
+    }
+
+
+@eel.expose
+def unpack_boot_image(path: str):
+    """Unpack a boot image using existing tool logic."""
+    try:
+        tk_tool.unpack_boot('boot', path)
+        return {"result": "ok"}
+    except Exception as e:  # pragma: no cover - just return error
+        return {"error": str(e)}
+
+
+@eel.expose
+def patch_boot_image(boot_path: str, magisk_apk: str, arch: str = 'arm64-v8a'):
+    """Patch a boot image with Magisk."""
+    tempdir = tempfile.mkdtemp(prefix='magisk_',)
+    try:
+        with Magisk_patch(
+            boot_path,
+            None,
+            f"{tool_bin}magiskboot",
+            tempdir,
+            True,
+            False,
+            False,
+            False,
+            magisk_apk,
+            arch,
+        ) as m:
+            m.auto_patch()
+            if m.output and os.path.exists(m.output):
+                return {"result": os.path.abspath(m.output)}
+            return {"error": "patch failed"}
+    except Exception as e:  # pragma: no cover - best effort
+        return {"error": str(e)}
+    finally:
+        shutil.rmtree(tempdir, ignore_errors=True)
+
+
+@eel.expose
+def choose_file():
+    """Open a native file dialog and return the selected path."""
+    try:
+        import tkinter as tk
+        from tkinter import filedialog
+
+        root = tk.Tk()
+        root.withdraw()
+        path = filedialog.askopenfilename()
+        root.destroy()
+        return path
+    except Exception as e:  # pragma: no cover - fallback on error
+        return ""
+
+
+def start():
+    """Launch the Eel web interface."""
+    # Use mode="none" to allow running in environments without a browser
+    eel.start('index.html', mode='none', size=(480, 320))
+
+if __name__ == '__main__':
+    start()

--- a/src/webui/web/battery.html
+++ b/src/webui/web/battery.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Batteries</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <a class="back-link" href="index.html">Back</a>
+        <h1>Batteries</h1>
+    </header>
+    <div class="widget-container page" id="container">
+        <div class="background"></div>
+    </div>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="battery.js"></script>
+</body>
+</html>

--- a/src/webui/web/battery.js
+++ b/src/webui/web/battery.js
@@ -1,0 +1,46 @@
+async function init() {
+    const data = await eel.get_batteries()();
+    const icons = ['\ud83d\udcf1', '\ud83d\udcbb', '\u231a', '\ud83c\udfa7'];
+    const container = document.getElementById('container');
+    function animate(progress, value) {
+        let deg = 0;
+        const target = (value / 100) * 360;
+        function step() {
+            deg += 6;
+            if (deg >= target) deg = target;
+            progress.style.setProperty('--value', deg + 'deg');
+            if (deg < target) requestAnimationFrame(step);
+        }
+        requestAnimationFrame(step);
+    }
+
+    data.forEach((value, idx) => {
+        const device = document.createElement('div');
+        device.className = 'device-container';
+
+        const track = document.createElement('div');
+        track.className = 'track';
+        const progress = document.createElement('div');
+        progress.className = 'progress';
+        progress.style.setProperty('--value', '0deg');
+        const overlay = document.createElement('div');
+        overlay.className = 'overlay';
+        const icon = document.createElement('div');
+        icon.className = 'device-icon';
+        icon.textContent = icons[idx % icons.length];
+
+        const reading = document.createElement('div');
+        reading.className = 'reading';
+        reading.textContent = value + '%';
+
+        device.appendChild(track);
+        device.appendChild(progress);
+        device.appendChild(overlay);
+        device.appendChild(icon);
+        device.appendChild(reading);
+        container.appendChild(device);
+        animate(progress, value);
+    });
+}
+
+init();

--- a/src/webui/web/common.js
+++ b/src/webui/web/common.js
@@ -1,0 +1,6 @@
+async function chooseFile(targetId) {
+    const path = await eel.choose_file()();
+    if (path) {
+        document.getElementById(targetId).value = path;
+    }
+}

--- a/src/webui/web/file_info.html
+++ b/src/webui/web/file_info.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Get File Info</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <a class="back-link" href="index.html">Back</a>
+        <h1>File Info</h1>
+    </header>
+    <div class="file-info-container page">
+        <input type="text" id="filePath" placeholder="Enter file path" class="text-input" />
+        <button class="btn" onclick="chooseFile('filePath')">Browse</button>
+        <button class="btn" onclick="getInfo()">Get Info</button>
+        <pre id="infoOutput"></pre>
+    </div>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="common.js"></script>
+    <script src="file_info.js"></script>
+</body>
+</html>

--- a/src/webui/web/file_info.js
+++ b/src/webui/web/file_info.js
@@ -1,0 +1,6 @@
+async function getInfo() {
+    const path = document.getElementById('filePath').value;
+    const info = await eel.get_file_info(path)();
+    const output = document.getElementById('infoOutput');
+    output.textContent = JSON.stringify(info, null, 2);
+}

--- a/src/webui/web/index.html
+++ b/src/webui/web/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mio Web UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <h1>MIO-KITCHEN</h1>
+    </header>
+    <div class="menu page">
+        <ul>
+            <li><a class="btn" href="battery.html">Battery Widget</a></li>
+            <li><a class="btn" href="file_info.html">Get File Info</a></li>
+            <li><a class="btn" href="tools.html">Tools</a></li>
+        </ul>
+    </div>
+</body>
+</html>

--- a/src/webui/web/style.css
+++ b/src/webui/web/style.css
@@ -1,0 +1,189 @@
+:root {
+    --bg: #202020;
+    --text: #E6EDED;
+    --accent: #34C85A;
+    --font-base: 'SF Pro Text', sans-serif;
+    --font-display: 'SF Pro Display', sans-serif;
+}
+
+body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-base);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+.top-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background: #111;
+    color: var(--text);
+    padding: 8px 0;
+    text-align: center;
+    z-index: 10;
+}
+
+.back-link {
+    position: absolute;
+    left: 10px;
+    top: 8px;
+    color: var(--text);
+    text-decoration: none;
+    font-size: 14px;
+}
+
+.page {
+    margin-top: 40px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.menu {
+    text-align: center;
+}
+.menu ul {
+    list-style: none;
+    padding: 0;
+}
+.menu li {
+    margin: 10px 0;
+}
+.menu a {
+    color: #E6EDED;
+    text-decoration: none;
+    font-size: 20px;
+}
+
+.widget-container {
+    position: relative;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 17.5px;
+    width: 338px;
+    height: 158px;
+    border-radius: 22px;
+}
+.widget-container .background {
+    position: absolute;
+    width: 338px;
+    height: 158px;
+    left: 0;
+    top: 0;
+    background: linear-gradient(0deg, #9C9C9C, #9C9C9C), rgba(37,37,37,0.55);
+    background-blend-mode: overlay, normal;
+    backdrop-filter: blur(50px);
+    border-radius: 20px;
+    z-index: 0;
+}
+.device-container {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 17px;
+    width: 62px;
+    height: 103px;
+    z-index: 1;
+}
+.track {
+    position: absolute;
+    width: 62px;
+    height: 62px;
+    left: 0;
+    top: 0;
+    background: rgba(217,217,217,0.2);
+    border-radius: 100px;
+}
+.progress {
+    position: absolute;
+    width: 62px;
+    height: 62px;
+    left: 0;
+    top: 0;
+    border-radius: 100px;
+    background: conic-gradient(var(--accent) var(--value), rgba(0,0,0,0) var(--value));
+    transform: rotate(-90deg);
+}
+.overlay {
+    position: absolute;
+    width: 6.15px;
+    height: 6.15px;
+    left: calc(50% - 3.075px);
+    top: 0.05px;
+    background: var(--accent);
+    box-shadow: 0.25px 0px 1px rgba(45,45,45,0.039), 2.5px 0px 3px rgba(45,45,45,0.19);
+}
+.device-icon {
+    position: absolute;
+    width: 34px;
+    height: 34px;
+    left: calc(50% - 17px);
+    top: calc(50% - 17px);
+    font-size: 26px;
+    text-align: center;
+    line-height: 34px;
+    color: #E6EDED;
+}
+.reading {
+    width: 62px;
+    height: 24px;
+    font-family: var(--font-display);
+    font-size: 22px;
+    line-height: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: #E6EDED;
+}
+
+.file-info-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 300px;
+}
+
+.tools-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 300px;
+}
+
+.tools-container h2 {
+    margin: 0;
+    padding-bottom: 5px;
+}
+
+.btn {
+    padding: 6px 12px;
+    background: var(--accent);
+    border: none;
+    border-radius: 6px;
+    color: var(--bg);
+    font-family: var(--font-base);
+    cursor: pointer;
+}
+
+.btn:hover {
+    filter: brightness(1.1);
+}
+
+.text-input {
+    padding: 4px 6px;
+    border: 1px solid #555;
+    border-radius: 4px;
+    background: #333;
+    color: var(--text);
+    font-family: var(--font-base);
+}

--- a/src/webui/web/tools.html
+++ b/src/webui/web/tools.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Tools</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header class="top-bar">
+        <a class="back-link" href="index.html">Back</a>
+        <h1>Tools</h1>
+    </header>
+    <div class="tools-container page">
+        <h2>Boot Tools</h2>
+        <input type="text" id="bootPath" placeholder="Path to boot.img" class="text-input" />
+        <button class="btn" onclick="chooseFile('bootPath')">Browse</button>
+        <button class="btn" onclick="unpackBoot()">Unpack Boot</button>
+        <pre id="toolOutput"></pre>
+        <hr />
+        <input type="text" id="patchBoot" placeholder="Boot img to patch" class="text-input" />
+        <button class="btn" onclick="chooseFile('patchBoot')">Browse</button>
+        <input type="text" id="magiskApk" placeholder="Magisk APK" class="text-input" />
+        <button class="btn" onclick="chooseFile('magiskApk')">Browse</button>
+        <button class="btn" onclick="patchBoot()">Patch Boot with Magisk</button>
+        <pre id="patchOutput"></pre>
+    </div>
+
+    <script type="text/javascript" src="/eel.js"></script>
+    <script src="common.js"></script>
+    <script src="tools.js"></script>
+</body>
+</html>

--- a/src/webui/web/tools.js
+++ b/src/webui/web/tools.js
@@ -1,0 +1,14 @@
+async function unpackBoot() {
+    const path = document.getElementById('bootPath').value;
+    const result = await eel.unpack_boot_image(path)();
+    const out = document.getElementById('toolOutput');
+    out.textContent = JSON.stringify(result, null, 2);
+}
+
+async function patchBoot() {
+    const boot = document.getElementById('patchBoot').value;
+    const apk = document.getElementById('magiskApk').value;
+    const res = await eel.patch_boot_image(boot, apk)();
+    const out = document.getElementById('patchOutput');
+    out.textContent = JSON.stringify(res, null, 2);
+}

--- a/web_tool.py
+++ b/web_tool.py
@@ -1,0 +1,4 @@
+from src.webui.app import start
+
+if __name__ == '__main__':
+    start()


### PR DESCRIPTION
## Summary
- expose `choose_file` in the web backend
- add `common.js` helper for browse buttons
- update file info and tools pages to use native dialogs
- document new browse buttons in the README

## Testing
- `python -m py_compile web_tool.py src/webui/app.py`
- `pip install Eel>=0.16.0`


------
https://chatgpt.com/codex/tasks/task_e_684fd769847483308051e22f4a68bd53